### PR TITLE
Added context to the plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module.exports = {
 You can customize the lint settings via a `.sass-lint.yml` file. See [sasslint options](https://github.com/sasstools/sass-lint/blob/develop/docs/sass-lint.yml), for complete options.
 
 * `configFile`: You can change the config file location. Default: (`.sass-lint.yml`)
+* `context`: Change the root of your SCSS files, by defualt inherits from webpack config.
 * `glob`: Change the glob pattern for finding files. Default: (`**/*.s?(a|c)ss`)
 * `quiet`: Suppress warnings, errors will still show. Default: `false`
 * `failOnWarning`: Have Webpack's build process die on warning. Default: `false`
@@ -44,6 +45,7 @@ module.exports = {
   plugins: [
     new sassLintPlugin({
       configFile: '.sass-lint.yml',
+      context: '[inherits from webpack]',
       glob: '**/*.s?(a|c)ss',
       quiet: false,
       failOnWarning: false,

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ function apply(options, compiler) {
   // acces to compiler and options
   compiler.plugin('compilation', function(compilation, params) {
     // Linter returns a simple report of FilePath + Warning or Errors
-    var report = linter(compiler.context + options.glob, options);
+    var context = options.context || compiler.context;
+    var report = linter(context + options.glob, options);
 
     // Hook into the compilation as early as possible, at the seal step
     compilation.plugin('seal', function() {


### PR DESCRIPTION
An unforeseen issue occurs when your webpack context has no JS files, needed to add an option to allow you to set your scss context separately. 
