### PR TITLE
Remove duplicate `nesting-depth` key

### DIFF
--- a/example/.sass-lint.yml
+++ b/example/.sass-lint.yml
@@ -17,7 +17,6 @@ rules:
   placeholder-in-extend: 1
   property-sort-order: 1
   property-spelling: 0
-  nesting-depth: 0
   shorthand: 0
   one-declaration-per-line: 1
   single-line-per-selector: 1


### PR DESCRIPTION
While running the example, I faced this error:

```
/Users/yangshun/Downloads/sasslint-webpack-plugin/node_modules/js-yaml/lib/js-yaml/loader.js:168
  throw generateError(state, message);
  ^
YAMLException: duplicated mapping key at line 20, column 19:
      nesting-depth: 0
```
