### PR TITLE
Fix redundant lint with extract-text-webpack-plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,15 @@ function apply(options, compiler) {
   });
 }
 
+// converts options specified as a string to Array
+function parseArrayTypeOptions(options, optionNames) {
+  optionNames.forEach(function(optionName) {
+    if (typeof options[optionName] === 'string') {
+      options[optionName] = [options[optionName]];
+    }
+  });
+}
+
 // makes it easier to pass and check options to the plugin thank you webpack doc
 // [https://webpack.github.io/docs/plugins.html#the-compiler-instance]
 module.exports = function(options) {
@@ -45,17 +54,11 @@ module.exports = function(options) {
   // under webpack's context and specificity changed via globbing patterns
   options.glob = options.glob || '**/*.s?(c|a)ss';
 
-  if (options.ignoreFiles && !Array.isArray(options.ignoreFiles)) {
-    options.ignoreFiles = [options.ignoreFiles];
-  }
-
-  if (options.ignorePlugins && !Array.isArray(options.ignorePlugins)) {
-    options.ignorePlugins = [options.ignorePlugins];
-  }
-
-  if (options.context && !Array.isArray(options.context)) {
-    options.context = [options.context];
-  }
+  parseArrayTypeOptions(options, [
+    'ignoreFiles',
+    'ignorePlugins',
+    'context'
+  ]);
 
   if (options instanceof Array) {
     options = {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ var linter = require('./lib/linter');
 function apply(options, compiler) {
   // acces to compiler and options
   compiler.plugin('compilation', function(compilation, params) {
+    // Avoid redundant lint when it is run in plugin like extract-text-webpack-plugin.
+    if(options.ignorePlugins.indexOf(compilation.name) >= 0) {
+      return;
+    }
     // Linter returns a simple report of FilePath + Warning or Errors
     var contexts = options.context || [compiler.context];
     var report = [];
@@ -43,6 +47,10 @@ module.exports = function(options) {
 
   if (options.ignoreFiles && !Array.isArray(options.ignoreFiles)) {
     options.ignoreFiles = [options.ignoreFiles];
+  }
+
+  if (options.ignorePlugins && !Array.isArray(options.ignorePlugins)) {
+    options.ignorePlugins = [options.ignorePlugins];
   }
 
   if (options.context && !Array.isArray(options.context)) {


### PR DESCRIPTION
When using with extract-text-webpack-plugin, you got redundant lint.
### Usage

``` diff
module.exports = {
  plugins: [
    new sassLintPlugin({
+     ignorePlugins: 'extract-text-webpack-plugin'
    }),
  ]
}
```
