### PR TITLE
Remove duplicate key in test/.sass-lint.yml

### DIFF
--- a/test/.sass-lint.yml
+++ b/test/.sass-lint.yml
@@ -17,7 +17,6 @@ rules:
   placeholder-in-extend: 1
   property-sort-order: 1
   property-spelling: 0
-  nesting-depth: 0
   shorthand: 0
   one-declaration-per-line: 2
   single-line-per-selector: 2


### PR DESCRIPTION
When I forked the project and tried to run the tests, I got three test failures due to a duplicate `nesting-depth` key in `test/.sass-lint.yml`.

This removes the duplicate key which allows the tests to pass.

NOTE: I’m using sass-lint 1.5.1, if that makes a difference.
